### PR TITLE
feat: Add mod_md to issue LE certs via ACME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN    mkdir -p /mnt/rootfs \
          glibc-minimal-langpack \
          hostname \
          httpd-core \
-         mod_ldap \
          mod_auth_openidc \
+         mod_ldap \
+         mod_md \
          mod_security \
          mod_security_crs \
          mod_session \


### PR DESCRIPTION
[mod_md](https://httpd.apache.org/docs/current/mod/mod_md.html) does ACME and OCSP stapling

* fixes #16 