### PR TITLE
fix: Store Apache HTTPD state in a volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,8 @@ RUN    useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default 
     && echo "IncludeOptional conf.d/local_configs/*.conf" \
     >> ${HTTPD_MAIN_CONF_PATH}/httpd.conf
 
+VOLUME /etc/httpd/state
+
 WORKDIR /opt/app-root/src
 
 USER 1001


### PR DESCRIPTION
I don't plan on using the state dir, but i might as well try making the server start before removing all my work.