### PR TITLE
chore(security): enable cosign checks on external images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,7 @@ jobs:
       image: ghcr.io/radiorabe/httpd
       name: nginx
       display-name: RaBe Apache HTTPD in UBI9
-      tags: minimal rhel9 ubi9 rabe apach ehttpd
-      cosign-base-image-only: true
+      tags: minimal rhel9 ubi9 rabe apache httpd
   mkdocs:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
I'm not sure if this is ready yet, this serves as a test.